### PR TITLE
Lem v2

### DIFF
--- a/Dauros.StellarisREG.DAL/Civic.cs
+++ b/Dauros.StellarisREG.DAL/Civic.cs
@@ -176,7 +176,7 @@ namespace Dauros.StellarisREG.DAL
                 //this should be Plantoid & Fungoid only
                 new Civic(EPN.C_DeathCult, EPN.D_Plantoids)
                 {
-                    Prohibits = new AndSet(){ EPN.Gestalt, EPN.A_Corporate, EPN.O_ShatteredRing, EPN.O_VoidDwellers,EPN.O_LifeSeeded }
+                    Prohibits = new AndSet(){ EPN.Gestalt, EPN.A_Corporate, EPN.O_ShatteredRing, EPN.O_VoidDwellers,EPN.O_LifeSeeded, EPN.AT_Lithoid }
                 }
             },
             {
@@ -485,7 +485,7 @@ namespace Dauros.StellarisREG.DAL
                 new Civic(EPN.C_IdyllicBloomHM, EPN.D_Utopia)
                 {
                     Requires = new HashSet<OrSet>(){new OrSet(){ EPN.A_HiveMind } },
-                    Prohibits = new AndSet(){ EPN.O_ShatteredRing,EPN.O_LifeSeeded }
+                    Prohibits = new AndSet(){ EPN.O_ShatteredRing,EPN.O_LifeSeeded, EPN.AT_Lithoid }
                 }
             },
             {

--- a/Dauros.StellarisREG.DAL/EmpirePropertyName.cs
+++ b/Dauros.StellarisREG.DAL/EmpirePropertyName.cs
@@ -174,11 +174,11 @@ namespace Dauros.StellarisREG.DAL
 
         #region Hive Mind
         public static String C_Ascetic => "Ascetic";
-        public static String C_CatalyticProcessingHM => "Catalytic Processing";
+        public static String C_CatalyticProcessingHM => "Catalytic Processing HM";
         public static String C_DevouringSwarm => "Devouring Swarm";
         public static String C_DividedAttention => "Divided Attention";
         public static String C_Empath => "Empath";
-        public static String C_IdyllicBloomHM => "Idyllic Bloom";
+        public static String C_IdyllicBloomHM => "Idyllic Bloom HM";
         public static String C_MemorialistHM => "Memorialist HM";
         public static String C_NaturalNeuralNetwork=> "Natural Neural Network";
         public static String C_OneMind => "One Mind";
@@ -192,7 +192,7 @@ namespace Dauros.StellarisREG.DAL
         #endregion
 
         #region Machine Intelligence
-        public static String C_CatalyticProcessingMI => "Catalytic Processing";
+        public static String C_CatalyticProcessingMI => "Catalytic Processing MI";
         public static String C_Constructobot => "Constructobot";
         public static String C_DelegatedFunctions => "Delegated Functions";
         public static String C_DeterminedExterminator => "Determined Exterminator";
@@ -214,7 +214,7 @@ namespace Dauros.StellarisREG.DAL
 
         #region Corporate
         public static String C_BrandLoyalty => "Brand Loyalty";
-        public static String C_CorporateCatalyticProcessing => "Catalytic Processing";
+        public static String C_CorporateCatalyticProcessing => "Corporate Catalytic Processing";
         public static String C_CorporateDeathCult => "Corporate Death Cult";
         public static String C_CorporateHedonism => "Corporate Hedonism";
         public static String C_CriminalHeritage => "Criminal Heritage";

--- a/Dauros.StellarisREG.DAL/EmpirePropertyName.cs
+++ b/Dauros.StellarisREG.DAL/EmpirePropertyName.cs
@@ -102,9 +102,9 @@ namespace Dauros.StellarisREG.DAL
         public static String D_Apocalypse => "Apocalypse";
         public static String D_AncientRelics => "Ancient Relics";
         public static String D_Necroids => "Necroids";
-        public static string D_Plantoids => "Plantoids";
-        public static string D_Humanoids => "Humanoids";
-        public static string D_Nemesis => "Nemesis";
+        public static String D_Plantoids => "Plantoids";
+        public static String D_Humanoids => "Humanoids";
+        public static String D_Nemesis => "Nemesis"; 
         #endregion
 
         #region Ethics

--- a/Dauros.StellarisREG.DAL/SelectState.cs
+++ b/Dauros.StellarisREG.DAL/SelectState.cs
@@ -23,7 +23,7 @@ namespace Dauros.StellarisREG.DAL
         public String? ArchetypeName { get; set; }
         public SpeciesArchetype? Archetype => ArchetypeName != null ? SpeciesArchetype.Collection[ArchetypeName] : null;
 
-        public static HashSet<String> AllDLC => new HashSet<string>() { EPN.D_AncientRelics, EPN.D_Apocalypse, EPN.D_Federations, EPN.D_Lithoids, EPN.D_Megacorp, EPN.D_Necroids, EPN.D_SyntheticDawn, EPN.D_Utopia };
+        public static HashSet<String> AllDLC => new HashSet<string>() { EPN.D_AncientRelics, EPN.D_Apocalypse, EPN.D_Federations, EPN.D_Lithoids, EPN.D_Megacorp, EPN.D_Necroids, EPN.D_SyntheticDawn, EPN.D_Utopia, EPN.D_Humanoids, EPN.D_Plantoids,EPN.D_Nemesis };
         /// <summary>
         /// Contains all EmpireProperties that are set on this SelectState
         /// </summary>

--- a/Dauros.StellarisREG.Web/Pages/Index.cshtml
+++ b/Dauros.StellarisREG.Web/Pages/Index.cshtml
@@ -1,7 +1,7 @@
 ﻿@page
 @model IndexModel
 @{
-    ViewData["Title"] = "Stellaris Random Empire Generator 2.8 (WiP)";
+    ViewData["Title"] = "Stellaris Random Empire Generator 3.1 (WiP)";
 }
 <div class="row">
     <div class="col-sm">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# StellarisREG 2.8
+# StellarisREG 3.1
 The Stellaris Random Empire Generator. Supports full reverse lookup.
 
 Simple dynamic webpage to generate empires with random settings for Stellaris 2.8. No database required. It runs a bit slow because it tests every single property addition against the full set multiple times.


### PR DESCRIPTION
Fixed catalytic processing duplicate key/values.
Humanoids/Plantoids/Nemesis DLC's and their dependants now display correctly.
Updated page to 3.1 to show updates & DLC are supported up to the 3.1 Lem release.